### PR TITLE
fix typos

### DIFF
--- a/src/ensRegistrar.ts
+++ b/src/ensRegistrar.ts
@@ -38,11 +38,15 @@ export function transfer(event: Transfer): void {
   }
 
   // Add the new owner to the list of historical owners of the domain
+
+
   let owners = transfer.getArray('owners')
   owners.push(Value.fromAddress(event.params.owner))
+  transfer.setArray('owners', owners)
+
 
   ensDomain.setString('id', id)
-  ensDomain.setAddress('owners', event.params.owner)
+  ensDomain.setAddress('owner', event.params.owner)
 
   store.set('Transfer', id, transfer as Entity)
   store.set('EnsDomain', id, ensDomain)


### PR DESCRIPTION
This should fix it. Before we weren't setting the new array. And also we had a typo for setting the new owner in EnsDomain, so that was not updating, but we wouldn't have been able to see that unless we explicitly looked for it 